### PR TITLE
☕ [Redux] Cafe Project 코드 리팩토링하기

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,10 @@
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-redux": "^9.2.0",
         "react-router-dom": "^6.23.1",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
         "sass": "^1.77.2"
       },
       "devDependencies": {
@@ -1143,13 +1146,13 @@
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1163,6 +1166,12 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
@@ -1621,7 +1630,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
@@ -3594,6 +3603,29 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -3642,6 +3674,21 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -4248,6 +4295,15 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-redux": "^9.2.0",
     "react-router-dom": "^6.23.1",
+    "redux": "^5.0.1",
+    "redux-thunk": "^3.1.0",
     "sass": "^1.77.2"
   },
   "devDependencies": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,27 +1,21 @@
-import { useState } from 'react'
-import './App.scss'
-import data from './assets/data'
-import Header from './components/Header'
-import Menu from './components/Menu'
-import { Route, Routes } from 'react-router-dom'
-import Cart from './components/Cart'
+import "./App.scss";
+import Header from "./components/Header";
+import Menu from "./components/Menu";
+import { Route, Routes } from "react-router-dom";
+import Cart from "./components/Cart";
 
 function App() {
-  const [ menu, setMenu ] = useState(data.menu)
-  const [ cart, setCart ] = useState([])
-  console.log(cart)
-
   return (
     <div>
       <Header />
       <main>
         <Routes>
-          <Route path='/' element={<Menu menu={menu} cart={cart} setCart={setCart} />}/>
-          <Route path='/cart' element={<Cart menu={menu} cart={cart} setCart={setCart} />}/>
+          <Route path="/" element={<Menu />} />
+          <Route path="/cart" element={<Cart />} />
         </Routes>
       </main>
     </div>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/components/Cart.jsx
+++ b/src/components/Cart.jsx
@@ -1,10 +1,14 @@
+import { useDispatch, useSelector } from "react-redux";
 import data from "../assets/data";
+import { removeFromCart } from "../redux/redux";
 
-function Cart({ menu, cart, setCart }) {
+function Cart() {
+  const menu = useSelector((state) => state.menuReducer);
+  const cart = useSelector((state) => state.cartReducer);
+
   if (!menu)
     return (
       <div style={{ textAlign: "center", margin: "80px" }}>
-        {" "}
         메뉴 정보가 없어요!
       </div>
     );
@@ -20,8 +24,6 @@ function Cart({ menu, cart, setCart }) {
               item={allMenus.find((menu) => menu.id === el.id)}
               options={el.options}
               quantity={el.quantity}
-              cart={cart}
-              setCart={setCart}
             />
           ))
         ) : (
@@ -32,7 +34,9 @@ function Cart({ menu, cart, setCart }) {
   );
 }
 
-function CartItem({ item, options, quantity, cart, setCart }) {
+function CartItem({ item, options, quantity }) {
+  const dispatch = useDispatch();
+
   return (
     <li className="cart-item">
       <div className="cart-item-info">
@@ -50,7 +54,7 @@ function CartItem({ item, options, quantity, cart, setCart }) {
       <button
         className="cart-item-delete"
         onClick={() => {
-          setCart(cart.filter((el) => item.id !== el.id));
+          dispatch(removeFromCart(item.id));
         }}
       >
         삭제

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import Item from "./Item";
 import OrderModal from "./OrderModal";
+import { useSelector } from "react-redux";
 
-function Menu({ menu, cart, setCart }) {
+function Menu() {
+  const menu = useSelector((state) => state.menuReducer);
   const [modalOn, setModalOn] = useState(false);
   const [modalMenu, setModalMenu] = useState(null);
   if (!menu)
@@ -36,12 +38,7 @@ function Menu({ menu, cart, setCart }) {
         );
       })}
       {modalOn ? (
-        <OrderModal
-          modalMenu={modalMenu}
-          setModalOn={setModalOn}
-          cart={cart}
-          setCart={setCart}
-        />
+        <OrderModal modalMenu={modalMenu} setModalOn={setModalOn} />
       ) : null}
     </>
   );

--- a/src/components/OrderModal.jsx
+++ b/src/components/OrderModal.jsx
@@ -1,63 +1,83 @@
-import { useState } from 'react'
-import data from '../assets/data'
+import { useState } from "react";
+import data from "../assets/data";
+import { useDispatch } from "react-redux";
+import { addToCart } from "../redux/redux";
 
-function OrderModal ({modalMenu, setModalOn, cart, setCart}) {
-    const [ options, setOptions ] = useState({'온도': 0, '진하기': 0, '사이즈': 0})
-    const [ quantity, setQuantity ] = useState(1)
-    const itemOptions = data.options
-    console.log(options)
-    return (
-        <>
-            {modalMenu ? (
-                <section className="modal-backdrop" onClick={() => setModalOn(false)}>
-                    <div className="modal" onClick={(e) => e.stopPropagation()}>
-                        <div className='modal-item'>
-                            <img src={modalMenu.img}/>
-                            <div>
-                                <h3>{modalMenu.name}</h3>
-                                <div>{modalMenu.description}</div>
-                            </div>
-                        </div>
-                        <ul className="options">
-                            {Object.keys(itemOptions).map(el => <Option 
-                                key={el} 
-                                options={options} 
-                                setOptions={setOptions} 
-                                name={el} 
-                                itemOptions={itemOptions[el]} 
-                            />)}
-                        </ul>
-                        <div className="submit">
-                            <div>
-                                <label htmlFor="count" >개수</label>
-                                <input id="count" type="number" value={quantity} min='1' onChange={(event) => setQuantity(Number(event.target.value))} />
-                            </div>
-                            <button onClick={() => {
-                                setCart([...cart, { options, quantity, id: modalMenu.id}])
-                                setModalOn(false)
-                            }}>장바구니 넣기</button>
-                        </div>
-                    </div>
-                </section>
-            ) : null}
-        </>
-    )
-}
-
-function Option ({name, options, setOptions, itemOptions}) {
-    return (
-        <li className='option'>
-            {name}
-            <ul>
-                {itemOptions.map((option, idx) => (
-                    <li key={option}>
-                        <input type='radio' name={name} checked={options[name] === idx} onChange={() => setOptions({...options, [name]: idx})} />
-                        {option}
-                    </li>
-                ))}
+function OrderModal({ modalMenu, setModalOn }) {
+  const dispatch = useDispatch();
+  const [options, setOptions] = useState({ 온도: 0, 진하기: 0, 사이즈: 0 });
+  const [quantity, setQuantity] = useState(1);
+  const itemOptions = data.options;
+  console.log(options);
+  return (
+    <>
+      {modalMenu ? (
+        <section className="modal-backdrop" onClick={() => setModalOn(false)}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <div className="modal-item">
+              <img src={modalMenu.img} />
+              <div>
+                <h3>{modalMenu.name}</h3>
+                <div>{modalMenu.description}</div>
+              </div>
+            </div>
+            <ul className="options">
+              {Object.keys(itemOptions).map((el) => (
+                <Option
+                  key={el}
+                  options={options}
+                  setOptions={setOptions}
+                  name={el}
+                  itemOptions={itemOptions[el]}
+                />
+              ))}
             </ul>
-        </li>
-    )
+            <div className="submit">
+              <div>
+                <label htmlFor="count">개수</label>
+                <input
+                  id="count"
+                  type="number"
+                  value={quantity}
+                  min="1"
+                  onChange={(event) => setQuantity(Number(event.target.value))}
+                />
+              </div>
+              <button
+                onClick={() => {
+                  dispatch(addToCart(options, quantity, modalMenu.id));
+                  setModalOn(false);
+                }}
+              >
+                장바구니 넣기
+              </button>
+            </div>
+          </div>
+        </section>
+      ) : null}
+    </>
+  );
 }
 
-export default OrderModal
+function Option({ name, options, setOptions, itemOptions }) {
+  return (
+    <li className="option">
+      {name}
+      <ul>
+        {itemOptions.map((option, idx) => (
+          <li key={option}>
+            <input
+              type="radio"
+              name={name}
+              checked={options[name] === idx}
+              onChange={() => setOptions({ ...options, [name]: idx })}
+            />
+            {option}
+          </li>
+        ))}
+      </ul>
+    </li>
+  );
+}
+
+export default OrderModal;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,13 @@ import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
 import "./index.css";
 import { BrowserRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+import { store } from "./redux/redux.js";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <BrowserRouter>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </BrowserRouter>
 );

--- a/src/redux/redux.js
+++ b/src/redux/redux.js
@@ -4,7 +4,7 @@ import { combineReducers, legacy_createStore } from "redux";
 import data from "../assets/data";
 
 // 장바구니에 아이템 추가 (OrderModal.jsx 참고)
-const addToCart = (options, quantity, id) => {
+export const addToCart = (options, quantity, id) => {
   return {
     type: "addToCart",
     payload: { options, quantity, id },
@@ -14,7 +14,7 @@ const addToCart = (options, quantity, id) => {
 // - 추후 price, name 같은 속성을 추가해도 구조 유지 가능
 
 // 장바구니 아이템 삭제 (Cart.jsx 참고)
-const removeFromCart = (id) => {
+export const removeFromCart = (id) => {
   return {
     type: "removeFromCart",
     payload: { id },
@@ -24,8 +24,8 @@ const removeFromCart = (id) => {
 
 // Reducer
 // cartReducer: cart 상태 관리
+// 초기값 빈 배열
 const cartReducer = (state = [], action) => {
-  // 초기값 빈 배열
   switch (action.type) {
     case "addToCart": // 기존 state에 새로운 아이템 추가
       return [...state, action.payload];
@@ -37,13 +37,11 @@ const cartReducer = (state = [], action) => {
 };
 
 // menuReducer: menu 상태 관리
+// 초기값 data.menu
 const menuReducer = (state = data.menu, action) => {
-  // 초기값 data.menu
   return state;
 };
 
 // store
-const rootReducer = combineReducers((cartReducer, menuReducer));
+const rootReducer = combineReducers({ cartReducer, menuReducer });
 export const store = legacy_createStore(rootReducer);
-
-// dispatch

--- a/src/redux/redux.js
+++ b/src/redux/redux.js
@@ -1,5 +1,6 @@
 // Action
 
+import { combineReducers, legacy_createStore } from "redux";
 import data from "../assets/data";
 
 // 장바구니에 아이템 추가 (OrderModal.jsx 참고)
@@ -41,5 +42,8 @@ const menuReducer = (state = data.menu, action) => {
   return state;
 };
 
-// dispatch
 // store
+const rootReducer = combineReducers((cartReducer, menuReducer));
+export const store = legacy_createStore(rootReducer);
+
+// dispatch

--- a/src/redux/redux.js
+++ b/src/redux/redux.js
@@ -1,4 +1,7 @@
-// action
+// Action
+
+import data from "../assets/data";
+
 // 장바구니에 아이템 추가 (OrderModal.jsx 참고)
 const addToCart = (options, quantity, id) => {
   return {
@@ -6,6 +9,8 @@ const addToCart = (options, quantity, id) => {
     payload: { options, quantity, id },
   };
 };
+// - payload: { options, quantity, id } 형태로 전달
+// - 추후 price, name 같은 속성을 추가해도 구조 유지 가능
 
 // 장바구니 아이템 삭제 (Cart.jsx 참고)
 const removeFromCart = (id) => {
@@ -14,7 +19,27 @@ const removeFromCart = (id) => {
     payload: { id },
   };
 };
+// - payload: { id } → 해당 id와 다른 아이템만 남기도록 filter 처리 진행
 
-// reducer
+// Reducer
+// cartReducer: cart 상태 관리
+const cartReducer = (state = [], action) => {
+  // 초기값 빈 배열
+  switch (action.type) {
+    case "addToCart": // 기존 state에 새로운 아이템 추가
+      return [...state, action.payload];
+    case "removeFromCart": // id가 일치하지 않는 요소만 남김
+      return state.filter((el) => action.payload.id !== el.id);
+    default:
+      return state;
+  }
+};
+
+// menuReducer: menu 상태 관리
+const menuReducer = (state = data.menu, action) => {
+  // 초기값 data.menu
+  return state;
+};
+
 // dispatch
 // store

--- a/src/redux/redux.js
+++ b/src/redux/redux.js
@@ -1,0 +1,20 @@
+// action
+// 장바구니에 아이템 추가 (OrderModal.jsx 참고)
+const addToCart = (options, quantity, id) => {
+  return {
+    type: "addToCart",
+    payload: { options, quantity, id },
+  };
+};
+
+// 장바구니 아이템 삭제 (Cart.jsx 참고)
+const removeFromCart = (id) => {
+  return {
+    type: "removeFromCart",
+    payload: { id },
+  };
+};
+
+// reducer
+// dispatch
+// store


### PR DESCRIPTION
## ☕ Redux 학습 PR (Cafe Project)

- Branch: refactor/redux
- Subject: 카페 프로젝트에 Redux 적용

<br>

## 🧩 Implementation

### Action / Reducer / Store
- `addToCart`, `removeFromCart` 액션 생성
- `cartReducer` 구현 → cart 상태 관리 (add/remove)
- `menuReducer` 구현 → 초기 메뉴 데이터 관리 (data.menu 활용)
- `combineReducers`로 cartReducer, menuReducer를 `rootReducer`로 통합
- legacy_createStore로 단일 store 생성


### React Redux 연결
- `Provider`로 React 컴포넌트 트리에 `store` 주입
  ```jsx
    <Provider store={store}>
        <App />
      </Provider>
  ```
### Menu 컴포넌트
- `useSelector`로 menu 상태 구독
- `dispatch(addToCart(...))` 실행

### Cart 컴포넌트
- `useSelector`로 cart 상태 구독
- `dispatch(removeFromCart(id))`로 삭제 기능 구현

<br>

## 📌 What I Learned
- Redux store에 다중 리듀서(cart, menu)를 통합하여 관리하는 방법
- `useSelector`와 `useDispatch`로 컴포넌트를 Redux store와 연결하는 패턴
- Flux : 버튼 클릭 → 액션 → 리듀서 → 상태 업데이트 → UI 반영 흐름을 직접 확인하며 이해

<br>

## 📚 Reference

Log
- [[Redux] Flux 패턴 학습을 위한 Counter 구현](https://github.com/miloupark/redux-playground/pull/1)

Docs
- [Redux](https://redux.js.org/)
- [React-Redux](https://react-redux.js.org/) 

GitHub
- [redux / redux](https://github.com/reduxjs/redux)
- [redux/ redux-toolkit](https://github.com/reduxjs/redux-toolkit)
- [redux / react-redux](https://github.com/reduxjs/react-redux)

<br>

--- 

💡 이 브랜치는 Redux 학습용 브랜치로, Redux Toolkit과 비교 학습을 위해 메인 브랜치에는 병합하지 않습니다.