### PR TITLE
☕ [Redux-Toolkit] Cafe Project 코드 리팩토링하기 (Redux → RTK)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "cafe",
       "version": "0.0.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^2.8.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-redux": "^9.2.0",
         "react-router-dom": "^6.23.1",
         "sass": "^1.77.2"
       },
@@ -876,6 +878,32 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.8.2.tgz",
+      "integrity": "sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.0.tgz",
@@ -1092,6 +1120,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1143,13 +1183,13 @@
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1163,6 +1203,12 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
@@ -1621,7 +1667,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
@@ -2628,6 +2674,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/immutable": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
@@ -3594,6 +3650,29 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -3644,6 +3723,21 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
@@ -3682,6 +3776,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.5",
@@ -4248,6 +4348,15 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^2.8.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-redux": "^9.2.0",
     "react-router-dom": "^6.23.1",
     "sass": "^1.77.2"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,27 +1,21 @@
-import { useState } from 'react'
-import './App.scss'
-import data from './assets/data'
-import Header from './components/Header'
-import Menu from './components/Menu'
-import { Route, Routes } from 'react-router-dom'
-import Cart from './components/Cart'
+import "./App.scss";
+import Header from "./components/Header";
+import Menu from "./components/Menu";
+import { Route, Routes } from "react-router-dom";
+import Cart from "./components/Cart";
 
 function App() {
-  const [ menu, setMenu ] = useState(data.menu)
-  const [ cart, setCart ] = useState([])
-  console.log(cart)
-
   return (
     <div>
       <Header />
       <main>
         <Routes>
-          <Route path='/' element={<Menu menu={menu} cart={cart} setCart={setCart} />}/>
-          <Route path='/cart' element={<Cart menu={menu} cart={cart} setCart={setCart} />}/>
+          <Route path="/" element={<Menu />} />
+          <Route path="/cart" element={<Cart />} />
         </Routes>
       </main>
     </div>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/components/Cart.jsx
+++ b/src/components/Cart.jsx
@@ -1,10 +1,14 @@
+import { useDispatch, useSelector } from "react-redux";
 import data from "../assets/data";
+import { cartSlice } from "../redux/redux";
 
-function Cart({ menu, cart, setCart }) {
+function Cart() {
+  const menu = useSelector((state) => state.menu);
+  const cart = useSelector((state) => state.cart);
+
   if (!menu)
     return (
       <div style={{ textAlign: "center", margin: "80px" }}>
-        {" "}
         메뉴 정보가 없어요!
       </div>
     );
@@ -20,8 +24,6 @@ function Cart({ menu, cart, setCart }) {
               item={allMenus.find((menu) => menu.id === el.id)}
               options={el.options}
               quantity={el.quantity}
-              cart={cart}
-              setCart={setCart}
             />
           ))
         ) : (
@@ -32,7 +34,9 @@ function Cart({ menu, cart, setCart }) {
   );
 }
 
-function CartItem({ item, options, quantity, cart, setCart }) {
+function CartItem({ item, options, quantity }) {
+  const dispatch = useDispatch();
+
   return (
     <li className="cart-item">
       <div className="cart-item-info">
@@ -50,7 +54,7 @@ function CartItem({ item, options, quantity, cart, setCart }) {
       <button
         className="cart-item-delete"
         onClick={() => {
-          setCart(cart.filter((el) => item.id !== el.id));
+          dispatch(cartSlice.actions.removeFromCart({ id: item.id }));
         }}
       >
         삭제

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -1,14 +1,15 @@
 import { useState } from "react";
 import Item from "./Item";
 import OrderModal from "./OrderModal";
+import { useSelector } from "react-redux";
 
-function Menu({ menu, cart, setCart }) {
+function Menu() {
+  const menu = useSelector((state) => state.menu);
   const [modalOn, setModalOn] = useState(false);
   const [modalMenu, setModalMenu] = useState(null);
   if (!menu)
     return (
       <div style={{ textAlign: "center", margin: "80px" }}>
-        {" "}
         메뉴 정보가 없어요!
       </div>
     );
@@ -36,12 +37,7 @@ function Menu({ menu, cart, setCart }) {
         );
       })}
       {modalOn ? (
-        <OrderModal
-          modalMenu={modalMenu}
-          setModalOn={setModalOn}
-          cart={cart}
-          setCart={setCart}
-        />
+        <OrderModal modalMenu={modalMenu} setModalOn={setModalOn} />
       ) : null}
     </>
   );

--- a/src/components/OrderModal.jsx
+++ b/src/components/OrderModal.jsx
@@ -1,63 +1,89 @@
-import { useState } from 'react'
-import data from '../assets/data'
+import { useState } from "react";
+import data from "../assets/data";
+import { useDispatch } from "react-redux";
+import { cartSlice } from "../redux/redux";
 
-function OrderModal ({modalMenu, setModalOn, cart, setCart}) {
-    const [ options, setOptions ] = useState({'온도': 0, '진하기': 0, '사이즈': 0})
-    const [ quantity, setQuantity ] = useState(1)
-    const itemOptions = data.options
-    console.log(options)
-    return (
-        <>
-            {modalMenu ? (
-                <section className="modal-backdrop" onClick={() => setModalOn(false)}>
-                    <div className="modal" onClick={(e) => e.stopPropagation()}>
-                        <div className='modal-item'>
-                            <img src={modalMenu.img}/>
-                            <div>
-                                <h3>{modalMenu.name}</h3>
-                                <div>{modalMenu.description}</div>
-                            </div>
-                        </div>
-                        <ul className="options">
-                            {Object.keys(itemOptions).map(el => <Option 
-                                key={el} 
-                                options={options} 
-                                setOptions={setOptions} 
-                                name={el} 
-                                itemOptions={itemOptions[el]} 
-                            />)}
-                        </ul>
-                        <div className="submit">
-                            <div>
-                                <label htmlFor="count" >개수</label>
-                                <input id="count" type="number" value={quantity} min='1' onChange={(event) => setQuantity(Number(event.target.value))} />
-                            </div>
-                            <button onClick={() => {
-                                setCart([...cart, { options, quantity, id: modalMenu.id}])
-                                setModalOn(false)
-                            }}>장바구니 넣기</button>
-                        </div>
-                    </div>
-                </section>
-            ) : null}
-        </>
-    )
-}
-
-function Option ({name, options, setOptions, itemOptions}) {
-    return (
-        <li className='option'>
-            {name}
-            <ul>
-                {itemOptions.map((option, idx) => (
-                    <li key={option}>
-                        <input type='radio' name={name} checked={options[name] === idx} onChange={() => setOptions({...options, [name]: idx})} />
-                        {option}
-                    </li>
-                ))}
+function OrderModal({ modalMenu, setModalOn }) {
+  const dispatch = useDispatch();
+  const [options, setOptions] = useState({ 온도: 0, 진하기: 0, 사이즈: 0 });
+  const [quantity, setQuantity] = useState(1);
+  const itemOptions = data.options;
+  console.log(options);
+  return (
+    <>
+      {modalMenu ? (
+        <section className="modal-backdrop" onClick={() => setModalOn(false)}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <div className="modal-item">
+              <img src={modalMenu.img} />
+              <div>
+                <h3>{modalMenu.name}</h3>
+                <div>{modalMenu.description}</div>
+              </div>
+            </div>
+            <ul className="options">
+              {Object.keys(itemOptions).map((el) => (
+                <Option
+                  key={el}
+                  options={options}
+                  setOptions={setOptions}
+                  name={el}
+                  itemOptions={itemOptions[el]}
+                />
+              ))}
             </ul>
-        </li>
-    )
+            <div className="submit">
+              <div>
+                <label htmlFor="count">개수</label>
+                <input
+                  id="count"
+                  type="number"
+                  value={quantity}
+                  min="1"
+                  onChange={(event) => setQuantity(Number(event.target.value))}
+                />
+              </div>
+              <button
+                onClick={() => {
+                  dispatch(
+                    cartSlice.actions.addToCart({
+                      options,
+                      quantity,
+                      id: modalMenu.id,
+                    })
+                  );
+                  setModalOn(false);
+                }}
+              >
+                장바구니 넣기
+              </button>
+            </div>
+          </div>
+        </section>
+      ) : null}
+    </>
+  );
 }
 
-export default OrderModal
+function Option({ name, options, setOptions, itemOptions }) {
+  return (
+    <li className="option">
+      {name}
+      <ul>
+        {itemOptions.map((option, idx) => (
+          <li key={option}>
+            <input
+              type="radio"
+              name={name}
+              checked={options[name] === idx}
+              onChange={() => setOptions({ ...options, [name]: idx })}
+            />
+            {option}
+          </li>
+        ))}
+      </ul>
+    </li>
+  );
+}
+
+export default OrderModal;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,13 @@ import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
 import "./index.css";
 import { BrowserRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+import { store } from "./redux/redux.js";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <BrowserRouter>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </BrowserRouter>
 );

--- a/src/redux/redux.js
+++ b/src/redux/redux.js
@@ -1,0 +1,28 @@
+import data from "../assets/data";
+import { configureStore, createSlice } from "@reduxjs/toolkit";
+
+export const menuSlice = createSlice({
+  name: "menu",
+  initialState: data.menu,
+  reducers: {},
+});
+
+export const cartSlice = createSlice({
+  name: "cart",
+  initialState: [],
+  reducers: {
+    addToCart(state, action) {
+      return [...state, action.payload];
+    },
+    removeFromCart(state, action) {
+      return state.filter((el) => action.payload.id !== el.id);
+    },
+  },
+});
+
+export const store = configureStore({
+  reducer: {
+    menu: menuSlice.reducer,
+    cart: cartSlice.reducer,
+  },
+});


### PR DESCRIPTION
## ☕ Redux Toolkit 학습 PR (Cafe Project Redux → RTK)

- Branch: refactor/redux-toolkit
- Subject: 카페 프로젝트에 Redux Toolkit 적용 

<br>

## 🧩 Implementation

### Slice / Store
- `menuSlice` 구현 → 초기 메뉴 데이터 관리 (data.menu 활용)
- `cartSlice` 구현 → 장바구니 상태 관리 (addToCart, removeFromCart)
- `configureStore`로 store 생성 및 slice reducer 등록


### React Redux 연결
- `Provider`로 React 컴포넌트 트리에 `store` 주입
  ```jsx
    <Provider store={store}>
        <App />
      </Provider>
  ```
### Menu 컴포넌트
- `useSelector`로 menu 상태 구독
- `dispatch(cartSlice.actions.addToCart(...))` 실행

### Cart 컴포넌트
- `useSelector`로 cart 상태 구독
- `dispatch(cartSlice.actions.removeFromCart(id))`로 삭제 기능 구현

<br>

## 📌 What I Learned
- RTK 기본 흐름: createSlice로 action/reducer 를 한 곳에서 정의, configureStore로 등록 후 useSelector, useDispatch로 연동
- Flux: 버튼 클릭 → slice 액션 호출 → reducer 실행 → 상태 업데이트 → UI 반영 흐름에 대한 이해


<br>

## 📚 Reference

Log
- [[Redux] Flux 패턴 학습을 위한 Counter 구현](https://github.com/miloupark/redux-playground/pull/1)
- [[Redux-Toolkit] Flux 패턴 학습을 위한 Counter 구현](https://github.com/miloupark/redux-playground/pull/3)

Docs
- [Redux](https://redux.js.org/)
- [Redux-Toolkit](https://redux-toolkit.js.org/)
- [React-Redux](https://react-redux.js.org/) 
- [Writing Logic with Thunks](https://redux.js.org/usage/writing-logic-thunks)
- [How to use the Redux Toolkit createAsyncThunk API to manage async calls](https://redux.js.org/tutorials/essentials/part-5-async-logic)

GitHub
- [redux / redux](https://github.com/reduxjs/redux)
- [redux/ redux-toolkit](https://github.com/reduxjs/redux-toolkit)
- [redux / react-redux](https://github.com/reduxjs/react-redux)
- [redux  / redux-thunk](https://github.com/reduxjs/redux-thunk?tab=readme-ov-file)
<br>

--- 

💡 이 브랜치는 Redux Toolkit 학습용 브랜치로, Redux Toolkit과 비교 학습을 위해 메인 브랜치에는 병합하지 않습니다.